### PR TITLE
ci: deploy to self-hosted server (blog.cbsama.uk)

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,0 +1,56 @@
+name: Deploy to server
+
+on:
+  push:
+    branches:
+      - main # default branch
+
+# Allow only one concurrent deploy
+concurrency:
+  group: deploy-server
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p ${{ secrets.DEPLOY_PORT }} -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy via rsync
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.DEPLOY_PORT }}" \
+            ./public/ \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:${{ secrets.DEPLOY_PATH }}/
+
+      - name: Clean up
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary

新增一个 GitHub Actions workflow，在 push 到 main 时构建 Hexo 并通过 rsync over SSH 同步发布到自建服务器（blog.cbsama.uk），与现有 GitHub Pages 部署并行运行。

## 配置说明

- **服务器**：静态文件直接由 host nginx 从 `/var/www/blog` 提供（无容器/无新端口，省内存）
- **nginx**：新增 `blog.conf`，`server_name blog.cbsama.uk`，复用通配证书，监听 443
- **DNS**：Cloudflare A 记录 `blog`（橙色云 proxied）已添加
- **Secrets**：`DEPLOY_SSH_KEY` / `DEPLOY_HOST` / `DEPLOY_PORT` / `DEPLOY_USER` / `DEPLOY_PATH`（专用 CI 部署密钥，私钥与服务器地址均存于 GitHub Secrets，不出现在仓库中）

## Test plan

- [x] 服务器 nginx 配置 `nginx -t` 通过并已 reload
- [x] CI 部署密钥 SSH 登录验证成功
- [ ] merge 后首次 workflow 运行，确认 rsync 成功且 https://blog.cbsama.uk 可访问

🤖 Generated with [Claude Code](https://claude.com/claude-code)